### PR TITLE
Add Mickaël Misbach as Committer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ The current Committers of the project are:
 
 * Benjamin Pelletier
 * Michael Barroco
+* Mickaël Misbach
 
 ## Technical Steering Committee
 


### PR DESCRIPTION
This PR is intended to capture majority approval by the existing committers (per [section 2](https://github.com/interuss/tsc/blob/main/CHARTER.md#2-technical-steering-committee).c.iii of the [InterUSS Technical Charter](https://github.com/interuss/tsc/blob/main/CHARTER.md)) to add Mickaël to the list of Committers.