### PR TITLE
Add style documentation

### DIFF
--- a/general_style_guide.md
+++ b/general_style_guide.md
@@ -1,0 +1,128 @@
+# InterUSS General Style Guide
+
+This document describes general practices or styles that should generally be
+used when adding or modifying content in InterUSS repositories.
+
+A guide specifically for Python code may be found in
+[a separate document](python_style_guide.md).
+
+## Magic strings
+
+Generally avoid repeating the same string literal in multiple places.  If a
+string is used in many places, it should generally be defined as a
+[constant](https://peps.python.org/pep-0008/#constants) and then that constant
+should be used instead.  This allows all instances to be discovered easily with
+an appropriate IDE, and it ensures that no typos are made in the literals.
+
+Docstrings for non-obvious constants are encouraged.
+
+## Magic values
+
+When the reason a numeric or other value has the value it has is not
+immediately obvious, define and document a constant and use the
+constant rather than the magic value.  When a constant is defined in a standard
+package, prefer that pre-existing definition rather than defining a new
+constant.
+
+No:
+
+```python
+foo = bar * 4.721
+```
+
+Yes:
+```python
+FOOS_PER_BAR = 4.721
+"""Number of foos in each bar."""
+
+foo = bar * FOOS_PER_BAR
+```
+
+No (when this limit is already defined in a standard package):
+```python
+FOO_LIMIT = 50
+"""Maximum number of foos according to Foo Standard."""
+```
+
+Yes:
+```python
+from uas_standards.foo_standard.v1.constants import FOO_LIMIT
+```
+
+## What and why, not how
+
+Function names should generally capture what is being done (often hinting at
+why) rather than how it is being done.  The focus should be the outcome rather
+than the method by which that outcome is obtained.
+
+| Yes                           | No |
+|-------------------------------| --- |
+| send_subscriber_notifications | send_foo_post_request_to_urls |
+| expect_client_notified        | expect_post_interaction_to_client |
+| op_intent_details_queried     | interactions_contains_get_request | 
+
+## Don't repeat yourself
+
+See [Wikipedia article](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
+
+In general, the same complex logic should not appear in more than one place as
+this introduces the possibility of inconsistency and reduces reusability.
+Instead, the complex logic should be encapsulated in a function that describes
+the concept the logic is embodying, and then that function should be called
+from the multiple places the duplicated logic used to reside.
+
+## Consistent naming style
+
+When referring to a particular entity, the name of that entity should be as consistent as possible.  Many naming conventions exist, but once one has been selected, it should be used as consistently as possible.  Namings for different entities of a similar type within the same document should generally follow the same convention.  The most common naming styles/conventions include:
+
+### Proper name
+
+Documentation:
+* ✅ "X will intersect with Conflicting Flight 1."
+* ✅ "Conflicting Flight 1 will start at X."
+* ❌ "Conflicting flight 1 will start at X."
+* ❌ "Conflicting_Flight_1 will start at X."
+* ❌ "Conflicting_flight_1 will start at X."
+* ❌ "X will intersect with Conflicting flight 1."
+* ❌ "X will intersect with conflicting flight 1."
+* ❌ "X will intersect with conflicting flight1."
+* ❌ "X will intersect with conflicting_flight_1."
+* ❌ "X will intersect with Conflicting_Flight_1."
+* ❌ "X will intersect with `Conflicting Flight 1`."
+
+Code:
+* ✅ `conflicting_flight1` or `conflicting_flight_1` (but select and use only one of these options)
+
+### Description
+
+Documentation:
+* ✅ "X will intersect with conflicting flight 1."
+* ✅ "Conflicting flight 1 will start at X."
+* ❌ "X will intersect with Conflicting Flight 1."
+* ❌ "X will intersect with Conflicting flight 1."
+* ❌ "X will intersect with conflicting flight1."
+* ❌ "X will intersect with conflicting_flight_1."
+* ❌ "X will intersect with Conflicting_Flight_1."
+* ❌ "X will intersect with `conflicting flight 1`."
+
+Code:
+* ✅ `conflicting_flight1` or `conflicting_flight_1` (but select and use only one of these options)
+
+### Code object
+
+(note that `conflicting_flight1` could be used instead of `conflicting_flight_1` in all ✅ options below, but whichever option is selected should be used consistently)
+
+Documentation:
+* ✅ "X will intersect with conflicting_flight_1."
+* ✅ "X will intersect with `conflicting_flight_1`."
+* ✅ "conflicting_flight_1 will start at X."
+* ✅ "`conflicting_flight_1` will start at X."
+* ❌ "X will intersect with conflicting flight 1."
+* ❌ "X will intersect with Conflicting Flight 1."
+* ❌ "X will intersect with Conflicting_Flight_1."
+* ❌ "Conflicting Flight 1 will start at X."
+* ❌ "Conflicting_Flight_1 will start at X."
+* ❌ "Conflicting_flight_1 will start at X."
+
+Code:
+* ✅ `conflicting_flight_1`

--- a/python_style_guide.md
+++ b/python_style_guide.md
@@ -5,6 +5,8 @@ when adding or modifying Python code in InterUSS repositories.  When guidelines
 below suggest different actions, the guideline nearest the top of this document
 should generally take precedence.
 
+General style guidelines may be found [in a separate document](general_style_guide.md).
+
 ## [Black](https://black.readthedocs.io/en/stable/)
 
 Black automatically formats Python code and can be invoked with `make format`.
@@ -46,6 +48,31 @@ is encouraged.
 Documentation should not consist solely of a reiteration of a component's name.
 If that is sufficient documentation, then comment-based documentation  is not
 necessary.
+
+Docstrings should not have any empty values.  If documentation is not needed
+for a particular parameter, return type, etc, that part of the docstring should
+be omitted:
+
+Yes (assuming the purpose and usage of `bar` is obvious):
+```python
+def foo(bar: int, baz: str) -> None:
+    """Foos the bar and baz.
+    
+    Args:
+        baz: Name of a thing.
+    """
+```
+
+No:
+```python
+def foo(bar: int, baz: str) -> None:
+    """Foos the bar and baz.
+    
+    Args:
+        bar:
+        baz: Name of a thing.
+    """
+```
 
 ## Data structures
 
@@ -89,16 +116,6 @@ my_implicitdict = MyObject(field1="foo", field2="bar")
 x = my_implicitdict.field1
 y = my_implicitdict.field2
 ```
-
-## Magic strings
-
-Generally avoid repeating the same string literal in multiple places.  If a
-string is used in many places, it should generally be defined as a
-[constant](https://peps.python.org/pep-0008/#constants) and then that constant
-should be used instead.  This allows all instances to be discovered easily with
-an appropriate IDE, and it ensures that no typos are made in the literals.
-
-Docstrings for non-obvious constants are encouraged.
 
 ## Default Python styles
 

--- a/repo_contributions.md
+++ b/repo_contributions.md
@@ -149,7 +149,7 @@ Once an [InterUSS committer](CONTRIBUTING.md#committers) approves the PR, they o
 
 1. Before your PR can be accepted, you must submit a Contributor License Agreement (CLA). See [here](https://github.com/interuss/tsc/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) for more details.
 
-1. Contributions involving Python code should generally follow the [InterUSS Python style guide](python_style_guide.md).
+1. Contributions should generally follow the [InterUSS general style guide](general_style_guide.md) and the [InterUSS Python style guide](python_style_guide.md) for Python code.
 
 1. The size/complexity of individual PRs is a key factor with respect to the quality and efficiency of the reviews. When [Large Contributions](#large-contributions) are required, they should be structured as a series of small and focused PRs. Here are some helpful references:
     - [Strategies For Small, Focused Pull Requests, Steve Hicks](https://artsy.github.io/blog/2021/03/09/strategies-for-small-focused-pull-requests/)


### PR DESCRIPTION
This PR adds documentation for style in both Python code and in general.  Note that nothing is deleted; blocks of deleted text have been moved to a different location.

Suggestions for adjustments or removals are welcome.