### PR TITLE
Add more docs for product users

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ The InterUSS Technical Charter is located in [CHARTER.md](CHARTER.md).  Note tha
 
 ## Collaboration Tools
 
+### GitHub
+
+GitHub is the primary tool used for collaborative development and usage of InterUSS products.  The [InterUSS GitHub organization](https://github.com/interuss) contains [multiple repositories](https://github.com/orgs/interuss/repositories) housing the various projects developed by InterUSS.
+
+Usage instructions are generally accessible from the README at the base of each repository.  To receive notifications about a product, click the Watch button near the upper right of its repository page (visible when logged into a GitHub account) and select the information of interest (e.g., issues, pull requests, releases, discussions, security alerts).
+
 ### Slack
 
 The InterUSS project maintains a [Slack Workspace](https://interuss.slack.com) for communication and collaboration.  This workspace is [open for anyone to join](https://join.slack.com/t/interuss/shared_invite/enQtNzg0OTcxOTIyNjc0LTQyYzM1MTljYWU1NDRkNjFkZmFlYjA0YTgwNjQ5N2U5OTVhMzBlZjY4NWE3YTgwYzVjNzg3ZjE5ZjRjM2M0ODQ).  Once you join the Slack Workspace, you can participate in any public channels. 

--- a/repo_contributions.md
+++ b/repo_contributions.md
@@ -4,6 +4,11 @@ Welcome to InterUSS and thank you for your interest in contributing to its repos
 
 In order to maximize the quality of contributions while keeping the time and energy spent by contributors and committers to a minimum, we kindly ask you to adhere to the practices described below.
 
+General open-source contribution guidelines can be found at:
+
+* [Open Source Guide's Host to Contribute to Open Source](https://opensource.guide/how-to-contribute)
+* [Cloud Native open-source contributing](https://contribute.cncf.io/contributors/getting-started/)
+
 ## Contributing procedure
 
 ![Contributing procedure flowchart](assets/contributing_procedure.svg)


### PR DESCRIPTION
This PR attempts to provide additional reference material for usage patterns observed in certain users.  Specifically, it explicitly mentions our primary collaboration tool (GitHub) along with an action a user may want to take there.  The PR also provides links to external open source contribution best practices.